### PR TITLE
Fixed possible confusing naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm install git+https://github.com/jacobp100/node-gcm-ccs.git
 Use via
 ```js
 var GCM = require('node-gcm-ccs');
-var gcm = GCM(<project id>, <api key>);
+var gcm = GCM(<project number>, <api key>);
 ```
 
 Getting an API Key


### PR DESCRIPTION
Since there is already a concept of project id in a gcloud it's not evident that it's actually the project id that should be used.
