### PR TITLE
Removed not needed dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Google Cloud Messaging via XMPP",
   "main": "node-gcm-ccs.js",
   "dependencies": {
-    "node-stringprep": "~0.7.2",
     "node-xmpp-client": "~2.1.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
node-stringprep is not compatible with latest node versions and makes impossible install node-gcm-ccs package
